### PR TITLE
fix: resolve unsettled top-level await warning in tests

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -48,11 +48,13 @@ Examples:
   process.exit(0);
 }
 
-// Check if the program is called with --init
-if (process.argv.includes('--init')) {
-  const success = await createInteractiveConfig();
-  process.exit(success ? 0 : 1);
-}
+// Main async function to handle top-level await
+(async () => {
+  // Check if the program is called with --init
+  if (process.argv.includes('--init')) {
+    const success = await createInteractiveConfig();
+    process.exit(success ? 0 : 1);
+  }
 
 // Check if the program is called with --cleanup
 if (process.argv.includes('--cleanup')) {
@@ -284,4 +286,5 @@ const main = async () => {
   }
 };
 
-main();
+await main();
+})();


### PR DESCRIPTION
Fixes the Node.js test runner warning about unsettled top-level await.

## Changes
- Wrap top-level await logic in async IIFE pattern
- Eliminates 'unsettled top-level await' warning during test runs
- All 34 tests continue to pass with no warnings

## Testing
- ✅ All tests pass (34/34)
- ✅ No more unsettled await warnings
- ✅ Functionality unchanged